### PR TITLE
7 allow running outside venv

### DIFF
--- a/src/autocommit.sh
+++ b/src/autocommit.sh
@@ -2,7 +2,16 @@
 
 autocommit() {
     local script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-    /media/bigdata/projects/auto-commit/venv/bin/python "$script_dir/main.py" "$@"
+    local repo_root="$(dirname "$script_dir")"
+    local venv_python="$repo_root/venv/bin/python"
+
+    if [ ! -x "$venv_python" ]; then
+        echo "Error: Python executable not found at $venv_python"
+        echo "Please ensure you have set up the virtual environment correctly"
+        return 1
+    fi
+
+    "$venv_python" "$script_dir/main.py" "$@"
 }
 
 # Export the function so it's available in subshells

--- a/src/autocommit.sh
+++ b/src/autocommit.sh
@@ -2,7 +2,7 @@
 
 autocommit() {
     local script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-    python "$script_dir/main.py" "$@"
+    /media/bigdata/projects/auto-commit/venv/bin/python "$script_dir/main.py" "$@"
 }
 
 # Export the function so it's available in subshells


### PR DESCRIPTION
- **fix: Use absolute path to Python interpreter in autocommit script**
- **feat: Improve autocommit.sh to dynamically locate venv Python executable**
